### PR TITLE
AVX-14941 : fixes to run in Terraform v1.0.6 and Aviatrix provider 2.20.0 version

### DIFF
--- a/mysecret.tfvars
+++ b/mysecret.tfvars
@@ -1,17 +1,18 @@
-aws_access_key      ="xxxxxxxxxxxxxxxxxxxx"
-aws_secret_key      ="xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"
-controller_ip       = "54.176.159.229"
-controller_username = "admin"
-controller_password = "password123"
-controller_email    = "user@domain.com"
+# AWS Credentials
+aws_access_key       = "_DONT_TRY_"
+aws_secret_key       = "_WARNING_YOU_"
 
-# 
-# Assume two VPCs (onprem and spoke)
-# already exists with instances
-#
+# Aviatrix Credentials
+account_name         = "EdselAWS"
+controller_ip        = "52.8.214.111"
+controller_username  = "username"
+controller_password  = "xxxxxxxxxxxx"
+
+# Assume two VPCs already exists with instances
 spoke_vpc_id         = "vpc-0cc2849a14c185847"
 spoke_subnet         = "10.10.80.0/20"
 spoke_ha_subnet      = "10.10.80.0/20"
 onprem_vpc_id        = "vpc-0f35d2839d5754ad8"
 onprem_subnet        = "172.16.5.0/24"
 vgw_id               = "vgw-07132d607eb041e4b"
+

--- a/provider.tf
+++ b/provider.tf
@@ -1,3 +1,12 @@
+terraform {
+  required_providers {
+    aviatrix = {
+      source = "AviatrixSystems/aviatrix"
+      version = "2.20"
+    }
+  }
+}
+
 provider "aws" {
   alias      = "ca-central-1"
   region     = "ca-central-1"

--- a/transit_network.tf
+++ b/transit_network.tf
@@ -23,27 +23,19 @@ resource "aviatrix_transit_gateway" "transit_gw" {
 
 module "ondemand_spoke" {
    source             = "./ondemand_spoke"
-   providers          = {
-      aws = "aws.us-west-2"
-   }
    tag                = local.ondemand_tag
    transit_gw         = aviatrix_transit_gateway.transit_gw.gw_name
 }
 
 module "spoke" {
    source             = "./spoke"
-   providers          = {
-      aws = "aws.us-west-2"
-   }
    tag                = local.spoke_tag
    transit_gw         = aviatrix_transit_gateway.transit_gw.gw_name
+
 }
 
 module "simulated_onprem" {
    source             = "./onprem"
-   providers          = {
-      aws = "aws.us-west-2"
-   }
    tag                = local.onprem_tag
    transit_gw         = aviatrix_transit_gateway.transit_gw.gw_name
 }

--- a/variables.tf
+++ b/variables.tf
@@ -1,7 +1,7 @@
-variable "controller_ip"       {}
-variable "controller_username" {}
-variable "controller_password" {}
-variable "account_name"        {}
+variable "controller_ip"       {default = "52.8.214.111"}
+variable "controller_username" {default = "admin"}
+variable "controller_password" {default = "Aviatrix123!"}
+variable "account_name"        {default = "EdselAWS"}
 variable "aws_access_key"      {}
 variable "aws_secret_key"      {}
 variable "ondemand_spoke_count"{default = 0}


### PR DESCRIPTION
These TF files were used to run during 6.2 release activemesh and it needs some overhaul to run for the latest terraform 1.0 and aviatrix provider 2.20.0. 

We will revive and start running it while 6.6 (conduit routing) is developing. 